### PR TITLE
Fix #3 - Add missing default `options`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,14 @@
 const visit = require(`unist-util-visit`);
 const getVideoId = require('get-video-id');
 
-module.exports = ({ markdownAST }, options = { width: 560, ratio: 1.7, related: false }) => {
+module.exports = ({ markdownAST }, opts) => {
+
+  const options = Object.assign(opts || {}, {
+    width: 560,
+    ratio: 1.77,
+    related: false
+  })
+
   const createIframe = (url, videoPlatform) => {
     if (options.ratio === undefined) {
       options.ratio = 1.77;


### PR DESCRIPTION
Default values in argument lists are set when argument is `undefined`. We need to handle `undefined` *and* `null` correctly by using `Object.assign`.

I also changed `ratio` from `1.7` to `1.77` to match the other occurrences.