### PR TITLE
Use inline style attribute

### DIFF
--- a/src/EmbedVideo.js
+++ b/src/EmbedVideo.js
@@ -51,18 +51,11 @@ function createIframe(url, videoService, options) {
               width="${options.width}" 
               height="${options.height}" 
               src="${url}"
-              class="embedVideo-iframe" 
+              class="embedVideo-iframe"
+              ${options.noIframeBorder ? 'style="border:0"' : ''}
               allowfullscreen
             ></iframe>
         </div>`;
-    if (options.noIframeBorder) {
-        iframeNode += `
-      <style>
-        .embedVideo-iframe {
-          border: 0
-        }
-      </style>`;
-    }
     if (videoService.additionalHTML) {
         iframeNode += videoService.additionalHTML;
     }

--- a/src/EmbedVideo.ts
+++ b/src/EmbedVideo.ts
@@ -64,18 +64,11 @@ function createIframe(url: string, videoService:IVideoService, options: IEmbedVi
               width="${options.width}" 
               height="${options.height}" 
               src="${url}"
-              class="embedVideo-iframe" 
+              class="embedVideo-iframe"
+              ${options.noIframeBorder ? 'style="border:0"' : ''}
               allowfullscreen
             ></iframe>
         </div>`
-  if (options.noIframeBorder) {
-    iframeNode += `
-      <style>
-        .embedVideo-iframe {
-          border: 0
-        }
-      </style>`
-  }
 
   if (videoService.additionalHTML) {
     iframeNode += videoService.additionalHTML;


### PR DESCRIPTION
When gatsbyjs/gatsby#12543 lands plugins will be able
to specify inline styling and it will be added to the
newly created iframe via gatsby-remark-responsive-iframe.

This will come with the advantage of being easier for other
projects like gatsby-mdx to parse and handle injected HTML
within the AST.

---

Related: https://github.com/gatsbyjs/gatsby/pull/12543