### PR TITLE
feat: 🎸 support custom markers other than using backtick

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 const config_1 = require("./src/config");
 const EmbedVideo_1 = require("./src/EmbedVideo");
+const remark_burger_1 = __importDefault(require("remark-burger"));
 const visit = require(`unist-util-visit`);
 const overrideDefaultOptions = (options) => {
     const videoOptions = Object.assign({}, config_1.defaultOptions, options);
@@ -11,17 +15,31 @@ const overrideDefaultOptions = (options) => {
 };
 const addVideoIframe = ({ markdownAST }, options) => {
     options = overrideDefaultOptions(options);
-    visit(markdownAST, `inlineCode`, (node) => {
-        const { value } = node;
+    const match = (node, v) => {
         const keywords = [...config_1.knownPlatforms(), 'video'].join('|');
         const re = new RegExp(`\(${keywords}\):\(\.\*\)`, 'i');
-        const processValue = value.match(re);
+        const processValue = v.match(re);
         if (processValue) {
             const type = processValue[1];
             const id = processValue[2].trim();
             node.type = `html`;
             node.value = EmbedVideo_1.embedVideoHTML(type, id, options);
         }
-    });
+    };
+    const { beginMarker, endMarker } = options;
+    if (beginMarker || endMarker) {
+        visit(markdownAST, `embedVideo`, (node) => {
+            const { data } = node;
+            match(node, data.content);
+        });
+    }
+    else {
+        visit(markdownAST, `inlineCode`, (node) => {
+            const { value } = node;
+            match(node, value);
+        });
+    }
 };
+const setParserPlugins = ({ beginMarker, endMarker }) => [[remark_burger_1.default, { beginMarker, endMarker, onlyRunWithMarker: true, pattyName: 'embedVideo' }]];
+addVideoIframe.setParserPlugins = setParserPlugins;
 module.exports = addVideoIframe;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@types/node": "^11.11.3",
     "get-video-id": "^3.1.0",
+    "remark-burger": "^1.0.0",
     "unist-util-visit": "^1.4.0"
   },
   "devDependencies": {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,6 +1,13 @@
 import { URL } from "url";
+import { RemarkBurgerOptions } from "remark-burger";
 
-interface IEmbedVideoOptions {
+interface Node {
+  type: string;
+  value: string;
+  data: { content: string };
+}
+
+interface IEmbedVideoOptions extends RemarkBurgerOptions {
   width: number;
   ratio: number;
   related?: boolean;
@@ -19,4 +26,3 @@ interface IVideoService {
   urlProcessing?: (id: string, url: URL, options: IEmbedVideoOptions) => URL;
   additionalHTML?: string;
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,11 @@ path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+remark-burger@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-burger/-/remark-burger-1.0.0.tgz#6cddfe0cecea5c9a96ba2a2edc52f4e9e93daa61"
+  integrity sha512-5kmsrdSwajpC92puE52TWdQub1m3K/Phuwp0oyLieMDabbUUqM+/1TaukHx0KrOUwjSRYCvCeaW3ROCoX+xhmw==
+
 right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"


### PR DESCRIPTION
This commit adds `remark-burger`, a custom parser that allow extracting
text between custom markers. It adds support for user-defined syntax
such as [[youtube: gdviJzEwShE]]

BREAKING CHANGE: 🧨 none

Hi Neal, here's the PR. Would love your feedback whenever you find the time!

close #18