### PR TITLE
use overriden options in setParserPlugins

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7,7 +7,7 @@ const EmbedVideo_1 = require("./EmbedVideo");
 const remark_burger_1 = __importDefault(require("remark-burger"));
 const visit = require(`unist-util-visit`);
 const overrideDefaultOptions = (options) => {
-    const videoOptions = Object.assign(Object.assign({}, config_1.defaultOptions), options);
+    const videoOptions = Object.assign({}, config_1.defaultOptions, options);
     if (!videoOptions.height) {
         videoOptions.height = Math.round(videoOptions.width / videoOptions.ratio);
     }
@@ -40,6 +40,10 @@ const addVideoIframe = ({ markdownAST }, options) => {
         });
     }
 };
-const setParserPlugins = ({ beginMarker, endMarker }) => [[remark_burger_1.default, { beginMarker, endMarker, onlyRunWithMarker: true, pattyName: 'embedVideo' }]];
+const setParserPlugins = (options) => {
+    options = overrideDefaultOptions(options);
+    const { beginMarker, endMarker } = options;
+    return [[remark_burger_1.default, { beginMarker, endMarker, onlyRunWithMarker: true, pattyName: 'embedVideo' }]];
+};
 addVideoIframe.setParserPlugins = setParserPlugins;
 module.exports = addVideoIframe;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "get-video-id": "^3.1.4",
-    "remark-burger": "^1.0.0",
+    "remark-burger": "^1.0.1",
     "unist-util-visit": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,11 @@ const addVideoIframe = ({ markdownAST }: any, options: IEmbedVideoOptions) => {
   }
 }
 
-const setParserPlugins = ({ beginMarker, endMarker }: IEmbedVideoOptions) =>
-  [[ plugin, { beginMarker, endMarker, onlyRunWithMarker: true, pattyName: 'embedVideo' } ]]
+const setParserPlugins = (options: IEmbedVideoOptions) => {
+  options = overrideDefaultOptions(options)
+  const { beginMarker, endMarker } = options;
+  return [[ plugin, { beginMarker, endMarker, onlyRunWithMarker: true, pattyName: 'embedVideo' } ]];
+}
 
 addVideoIframe.setParserPlugins = setParserPlugins;
 export = addVideoIframe;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -17,6 +17,8 @@ interface IEmbedVideoOptions extends RemarkBurgerOptions {
     id: string,
     embedURL: (videoId: string) => string
   }[];
+  beginMarker?: string;
+  endMarker?: string;
 }
 
 interface IVideoId {


### PR DESCRIPTION
Hi Neal! a tiny edit to fix an issue with MDX:

- Properly use overridden options in `setParserPlugins`
- Fix compatible issue with MDX (https://github.com/gatsbyjs/gatsby/issues/18135)