### PR TITLE
Adding sandbox attribute to <iframe> tag due to security reasons

### DIFF
--- a/dist/EmbedVideo.js
+++ b/dist/EmbedVideo.js
@@ -59,6 +59,7 @@ function createIframe(url, id, videoService, options) {
               ${options.iframeId ? `id="${id}"` : ""}
               loading="${loadingStrategy}"
               allowfullscreen
+	      sandbox
             ></iframe>
         </div>`;
     if (videoService.additionalHTML) {

--- a/dist/EmbedVideo.js
+++ b/dist/EmbedVideo.js
@@ -59,7 +59,7 @@ function createIframe(url, id, videoService, options) {
               ${options.iframeId ? `id="${id}"` : ""}
               loading="${loadingStrategy}"
               allowfullscreen
-	      sandbox
+	      sandbox="allow-same-origin allow-scripts allow-popups"
             ></iframe>
         </div>`;
     if (videoService.additionalHTML) {

--- a/src/EmbedVideo.ts
+++ b/src/EmbedVideo.ts
@@ -79,7 +79,7 @@ function createIframe(
               ${options.iframeId ? `id="${id}"` : ""}
               loading="${loadingStrategy}"
               allowfullscreen
-	      sandbox
+	      sandbox="allow-same-origin allow-scripts allow-popups"
             ></iframe>
         </div>`;
 

--- a/src/EmbedVideo.ts
+++ b/src/EmbedVideo.ts
@@ -79,6 +79,7 @@ function createIframe(
               ${options.iframeId ? `id="${id}"` : ""}
               loading="${loadingStrategy}"
               allowfullscreen
+	      sandbox
             ></iframe>
         </div>`;
 


### PR DESCRIPTION
Each `<iframe>` tag should be considered untrusted and therefore be running in sandbox mode.