### PR TITLE
Update sandbox example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ const config: GatsbyConfig = {
               ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
               containerClass: "embedVideo-container", //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
               iframeId: false, //Optional: if true, iframe's id will be set to what is provided after 'video:' (YouTube IFrame player API requires iframe id)
-              sandbox: 'allow-same-origin allow-scripts allow-presentation', // Optional: iframe sandbox options - Default: undefined
+              sandbox: "'allow-same-origin allow-scripts allow-presentation'", // Optional: iframe sandbox options - Default: undefined
             },
           },
            "gatsby-remark-responsive-iframe", //Optional: Must be loaded after gatsby-remark-embed-video


### PR DESCRIPTION
Update sandbox example in README to use quoted value.

Without the quotes, the rendered iframe will assign only the first sandbox attribute to `sandbox`

![wrong sandbox attrs](https://user-images.githubusercontent.com/1308495/193862100-4d7ba939-9ad5-4cb1-80bb-92312dacb03b.png)

When wrapping the option value with quotes, the whole string literal is assigned to rendered iframe:
![correct sandbox attrs](https://user-images.githubusercontent.com/1308495/193862682-19d7a3b4-d4b6-4b0f-8ae1-9ab4e81043b9.png)
